### PR TITLE
Still rendering

### DIFF
--- a/console.cc
+++ b/console.cc
@@ -213,11 +213,11 @@ render(SDL_Window *window)
 	for (int i = 0; i < SCREEN_COLS; i++) {
 		for (int j = 0; j < SCREEN_ROWS; j++) {
 			glyph g = book[screen[j + SCREEN_COLS * i]];
-			float x = base_x + 1.0f / window_width * (d.bearing_x),
-				  y = base_y + (1.0f / window_height * (-d.descender / 64.0f)) -
-					  1.0f / window_height * (d.height - d.bearing_y),
-				  w = 1.0f / window_width * (c.advance_x / 64.0f),
-				  h = 1.0f / window_height * (c.advance_y / 64.0f);
+			float x = base_x + 1.0f / window_width * (g.bearing_x),
+				  y = base_y + (1.0f / window_height * (-g.descender / 64.0f)) -
+					  1.0f / window_height * (g.height - g.bearing_y),
+				  w = 1.0f / window_width * (g.advance_x / 64.0f),
+				  h = 1.0f / window_height * (g.advance_y / 64.0f);
 			
 			g.render(x, y);
 			base_x += w;

--- a/console.cc
+++ b/console.cc
@@ -278,7 +278,7 @@ main(int argc, char *argv[])
 	// TODO: Get a list of suggested fonts. Consider Consolas, Lucidia Console.
 	//   consola.ttf, lucon.ttf.
 #if defined(__APPLE__)
-	if (FT_New_Face(library, "/Library/Fonts/Andale Mono.ttf", 0, &face)) {
+	if (FT_New_Face(library, "/System/Library/Fonts/Monaco.dfont", 0, &face)) {
 #elif defined(__GNUG__)
 	if (FT_New_Face(library,
 		"/usr/share/fonts/ubuntu-font-family/UbuntuMono-R.ttf", 0, &face)) {


### PR DESCRIPTION
I just realized I fudged up this PR, but oh well.

Anyway, the glyph being used for x,y were different than what was used for w,h. As far as I understand the logic, these should all be set to the current glyph. This is what this PR does (and also, unfortunately changes font but you know).

The result is that fonts are rendered in the same spot always, as far as my tests have been showing so far.