### PR TITLE
Fixes incorrect rendering of certain glyphs

### DIFF
--- a/console.cc
+++ b/console.cc
@@ -134,7 +134,7 @@ int window_width, window_height, displays;
 float ddpi, vdpi, hdpi;
 GLuint texture;
 
-string initial_glyphs = "abcdefghijklmnopqrstuvwxyz0123456789";
+string initial_glyphs = "abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()`~-_=+[{]}\\|;:'\",<.>/?";
 // TODO: Make this unicode-aware. It was map<string, glyph>.
 map<unsigned char, glyph> book;
 unsigned char *screen;
@@ -213,11 +213,11 @@ render(SDL_Window *window)
 	for (int i = 0; i < SCREEN_COLS; i++) {
 		for (int j = 0; j < SCREEN_ROWS; j++) {
 			glyph g = book[screen[j + SCREEN_COLS * i]];
-			float x = base_x + 1.0f / window_width * (d.bearing_x),
-				  y = base_y + (1.0f / window_height * (-d.descender / 64.0f)) -
-					  1.0f / window_height * (d.height - d.bearing_y),
-				  w = 1.0f / window_width * (c.advance_x / 64.0f),
-				  h = 1.0f / window_height * (c.advance_y / 64.0f);
+			float x = base_x + 1.0f / window_width * (g.bearing_x),
+				  y = base_y + (1.0f / window_height * (-g.descender / 64.0f)) -
+					  1.0f / window_height * (g.height - g.bearing_y),
+				  w = 1.0f / window_width * (g.advance_x / 64.0f),
+				  h = 1.0f / window_height * (g.advance_y / 64.0f);
 			
 			g.render(x, y);
 			base_x += w;

--- a/console.cc
+++ b/console.cc
@@ -42,13 +42,13 @@ using namespace std;
 
 class glyph {
 public:
-	unsigned bearing_x, bearing_y;
+	int bearing_x, bearing_y;
 	// TODO: Should internal format of 1/64ths of a point be kept?
 	// TODO: Make sure all math involving font positioning is floating point.
-	unsigned advance_x, advance_y;
+	int advance_x, advance_y;
 	// TODO: Find a better place to put this.
-	unsigned descender;
-	GLuint width, height;
+	int descender;
+	int width, height;
 	GLuint texture;
 	glyph();
 	glyph(FT_Face face, FT_ULong codepoint);


### PR DESCRIPTION
If bearingY > height, unsigned operations cause a very large value to be used and glyphs will be rendered outside of the viewing area.